### PR TITLE
slow-mode: emit events on pi.events bus during user approval

### DIFF
--- a/slow-mode/index.ts
+++ b/slow-mode/index.ts
@@ -132,12 +132,15 @@ export default function slowMode(pi: ExtensionAPI) {
     writeFileSync(stagePath, content, "utf-8");
 
     // Show review UI — user decides to approve/reject
+    // Emit event so other extensions can track when user approval is pending
+    pi.events.emit("slow-mode:waiting");
     const approved = await showReview(ctx, {
       operation: "WRITE",
       filePath: relPath,
       stagePath,
       body: content,
     });
+    pi.events.emit("slow-mode:resolved");
 
     // Clean up staged file after decision
     cleanup(stagePath);
@@ -187,6 +190,9 @@ export default function slowMode(pi: ExtensionAPI) {
 
     let approved: boolean;
 
+    // Emit event so other extensions can track when user approval is pending
+    pi.events.emit("slow-mode:waiting");
+
     // Try to open in external diff viewer first (preferred)
     const diffTool = findDiffTool();
     if (diffTool) {
@@ -224,6 +230,8 @@ export default function slowMode(pi: ExtensionAPI) {
         newPath,
       });
     }
+
+    pi.events.emit("slow-mode:resolved");
 
     // Clean up staged files after decision
     cleanup(oldPath);


### PR DESCRIPTION
Emit `slow-mode:waiting` and `slow-mode:resolved` events via `pi.events` when the extension is waiting for user to approve/reject a write or edit.

This allows other extensions to react to the approval state, e.g. updating a tmux status indicator to show that user input is needed.

Example consumer:

```typescript
pi.events.on("slow-mode:waiting", () => setStatus("waiting"));
pi.events.on("slow-mode:resolved", () => setStatus("working"));
```