### PR TITLE
feat(fetch): add html strip logic and handle larger request

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@marckrenn/pi-sub-core": "*",
-    "@marckrenn/pi-sub-bar": "*"
+    "@marckrenn/pi-sub-bar": "*",
+    "@mozilla/readability": "^0.5.0",
+    "jsdom": "^25.0.1"
   },
   "peerDependencies": {
     "@mariozechner/pi-ai": "*",


### PR DESCRIPTION
This adds a rudimentary logic of regex match to remove unnecessary data from fetch.

Also, I added Mozilla's readability support to strip more, allowing getting more relevant details only.