### PR TITLE
notify: wrap OSC sequences for tmux passthrough

### DIFF
--- a/notify/index.ts
+++ b/notify/index.ts
@@ -20,13 +20,26 @@ function sanitize(s: string): string {
 	return s.replace(/[\x00-\x1f\x7f;]/g, " ").trim();
 }
 
+/**
+ * tmux only forwards unknown OSC sequences to the outer terminal when they
+ * are wrapped in its DCS passthrough (\ePtmux;...\e\\) — even with
+ * `allow-passthrough on`. Detect tmux via $TMUX and double-escape ESC bytes.
+ */
+function writeEscape(seq: string): void {
+	if (process.env.TMUX) {
+		process.stdout.write(`\x1bPtmux;${seq.replaceAll("\x1b", "\x1b\x1b")}\x1b\\`);
+	} else {
+		process.stdout.write(seq);
+	}
+}
+
 function notifyOSC777(title: string, body: string): void {
-	process.stdout.write(`\x1b]777;notify;${sanitize(title)};${sanitize(body)}\x07`);
+	writeEscape(`\x1b]777;notify;${sanitize(title)};${sanitize(body)}\x07`);
 }
 
 function notifyOSC99(title: string, body: string): void {
-	process.stdout.write(`\x1b]99;i=1:d=0;${sanitize(title)}\x1b\\`);
-	process.stdout.write(`\x1b]99;i=1:p=body;${sanitize(body)}\x1b\\`);
+	writeEscape(`\x1b]99;i=1:d=0;${sanitize(title)}\x1b\\`);
+	writeEscape(`\x1b]99;i=1:p=body;${sanitize(body)}\x1b\\`);
 }
 
 function notifyWindows(title: string, body: string): void {


### PR DESCRIPTION
tmux swallows unknown OSC sequences like 777 and 99 instead of forwarding them to the outer terminal, so notifications never reached Ghostty/Kitty when pi runs inside a tmux pane. The `allow-passthrough` option only honours sequences explicitly wrapped in the DCS `\ePtmux;...\e\\` envelope.

Detect `$TMUX` and wrap the escape (doubling inner ESC bytes) so the host terminal receives the original OSC unchanged. Outside tmux behaviour is unaffected.