### PR TITLE
statusline: add contextFormat setting for absolute token counts

### DIFF
--- a/README.org
+++ b/README.org
@@ -134,7 +134,7 @@ Segments (left to right):
 |-----------+----------------------+-----------------------------------------|
 | Model     | =Opus 4.6=           | Current model (stripped "Claude " prefix) |
 | Usage     | =5h:4%│W:65% 1d22h=  | Subscription usage, reset time when >50% |
-| Context   | =12%/1.0M=           | Context window usage                    |
+| Context   | =12%/1.0M=           | Context window usage (or =24k/1.0M= with =contextFormat: absolute=) |
 | Thinking  | =think:med=          | Thinking level (hidden when off)         |
 | Path      | =myproject=          | Current directory basename               |
 | VCS       | =◆ main ~2 +3=       | jj(◆)/git branch with file counts       |
@@ -148,6 +148,7 @@ Usage colours: dim when fine, yellow when >70% used, red when >90% used.
 | =/statusline=        | Toggle on/off          |
 | =/statusline usage=  | Toggle usage display   |
 | =/statusline bar=    | Toggle entire bar      |
+| =/statusline context= | Toggle percent/absolute context tokens |
 
 #+html:</details>
 

--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -59,7 +59,7 @@ export default function statusline(pi: ExtensionAPI) {
 					if (!currentCtx) return [];
 					const thinkingLevel = getThinkingLevelFn?.() ?? "off";
 					const subUsage = settings.showUsage ? getUsage() : undefined;
-					const barCtx = buildBarContext(currentCtx, thinkingLevel, subUsage);
+					const barCtx = buildBarContext(currentCtx, thinkingLevel, subUsage, settings.contextFormat);
 					const line = renderBar(theme, barCtx, width);
 					if (!line) return [];
 					return [line];
@@ -190,7 +190,7 @@ export default function statusline(pi: ExtensionAPI) {
 	// ── Command ──────────────────────────────────────────────────────────
 
 	pi.registerCommand("statusline", {
-		description: "Toggle statusline on/off, or configure: /statusline [usage|bar]",
+		description: "Toggle statusline on/off, or configure: /statusline [usage|bar|context]",
 		handler: async (args, ctx) => {
 			currentCtx = ctx;
 			const arg = args?.trim().toLowerCase();
@@ -223,6 +223,14 @@ export default function statusline(pi: ExtensionAPI) {
 				return;
 			}
 
+			if (arg === "context") {
+				settings.contextFormat = settings.contextFormat === "percent" ? "absolute" : "percent";
+				saveSettings(settings);
+				renderWidget();
+				ctx.ui.notify(`Context: ${settings.contextFormat}`, "info");
+				return;
+			}
+
 			if (arg === "bar") {
 				settings.showBar = !settings.showBar;
 				saveSettings(settings);
@@ -231,7 +239,7 @@ export default function statusline(pi: ExtensionAPI) {
 				return;
 			}
 
-			ctx.ui.notify("Usage: /statusline [usage|bar]", "info");
+			ctx.ui.notify("Usage: /statusline [usage|bar|context]", "info");
 		},
 	});
 }

--- a/statusline/src/bar.ts
+++ b/statusline/src/bar.ts
@@ -8,7 +8,7 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { visibleWidth, truncateToWidth } from "@mariozechner/pi-tui";
 import { basename } from "node:path";
 import { getVcsStatus, invalidateVcs } from "./vcs.js";
-import type { UsageSnapshot } from "./types.js";
+import type { ContextFormat, UsageSnapshot } from "./types.js";
 
 // ── Extension statuses ───────────────────────────────────────────────────
 
@@ -63,8 +63,10 @@ export interface BarContext {
 	sessionBranch: ReturnType<any>;
 	usingSubscription: boolean;
 	usage: { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number };
+	contextTokens: number;
 	contextPercent: number;
 	contextWindow: number;
+	contextFormat: ContextFormat;
 	/** Subscription usage snapshot (from providers) */
 	subUsage: UsageSnapshot | undefined;
 }
@@ -144,7 +146,8 @@ function segContext(theme: Theme, ctx: BarContext): string | null {
 	if (!ctx.contextWindow) return null;
 	const pct = ctx.contextPercent;
 	const color = pct > 90 ? "error" : pct > 70 ? "warning" : "dim";
-	return theme.fg(color, `${pct.toFixed(0)}%/${fmtTokens(ctx.contextWindow)}`);
+	const used = ctx.contextFormat === "absolute" ? fmtTokens(ctx.contextTokens) : `${pct.toFixed(0)}%`;
+	return theme.fg(color, `${used}/${fmtTokens(ctx.contextWindow)}`);
 }
 
 function segCost(theme: Theme, ctx: BarContext): string | null {
@@ -178,7 +181,12 @@ export function renderBar(theme: Theme, ctx: BarContext, width: number): string 
 /**
  * Compute BarContext from an ExtensionContext.
  */
-export function buildBarContext(ctx: any, thinkingLevel: string, subUsage?: UsageSnapshot): BarContext {
+export function buildBarContext(
+	ctx: any,
+	thinkingLevel: string,
+	subUsage?: UsageSnapshot,
+	contextFormat: ContextFormat = "percent",
+): BarContext {
 	let input = 0,
 		output = 0,
 		cacheRead = 0,
@@ -214,8 +222,10 @@ export function buildBarContext(ctx: any, thinkingLevel: string, subUsage?: Usag
 		sessionBranch: null,
 		usingSubscription,
 		usage: { input, output, cacheRead, cacheWrite, cost },
+		contextTokens,
 		contextPercent,
 		contextWindow,
+		contextFormat,
 		subUsage: subUsage,
 	};
 }

--- a/statusline/src/types.ts
+++ b/statusline/src/types.ts
@@ -44,14 +44,19 @@ export interface UsageSnapshot {
 
 // ── Settings ─────────────────────────────────────────────────────────────
 
+export type ContextFormat = "percent" | "absolute";
+
 export interface StatuslineSettings {
 	/** Show usage widget below editor */
 	showUsage: boolean;
 	/** Show status bar below editor */
 	showBar: boolean;
+	/** How to render context-window usage: "42%/200k" vs "84k/200k" */
+	contextFormat: ContextFormat;
 }
 
 export const DEFAULT_SETTINGS: StatuslineSettings = {
 	showUsage: true,
 	showBar: true,
+	contextFormat: "percent",
 };


### PR DESCRIPTION
The percentage display is compact but hides how close you are to a hard limit when working near a known token budget (e.g. "is 12% of 1M still under the 150k I want to stay below?"). Some users reason in raw tokens.

Adds a `contextFormat` setting (`"percent"` | `"absolute"`, default unchanged) and a `/statusline context` subcommand to toggle it. Colour thresholds remain percentage-based so warning semantics are identical.

```json
{
  "contextFormat": "absolute"
}
```

Renders as `24k/1.0M` instead of `12%/1.0M`.