### PR TITLE
direnv: use valid theme color token

### DIFF
--- a/direnv/index.ts
+++ b/direnv/index.ts
@@ -38,7 +38,7 @@ export default function (pi: ExtensionAPI) {
 		const text =
 			status === "blocked"
 				? ctx.ui.theme.fg("warning", "direnv:blocked")
-				: ctx.ui.theme.fg("danger", "direnv:error");
+				: ctx.ui.theme.fg("error", "direnv:error");
 		ctx.ui.setStatus("direnv", text);
 	}
 


### PR DESCRIPTION
pi's theme schema defines `error`, not `danger`. Calling `ctx.ui.theme.fg("danger", ...)` throws `Unknown theme color: danger` whenever direnv reports an error state, which crashes the whole TUI on startup:

```
Error: Unknown theme color: danger
    at Proxy.fg (.../dist/modes/interactive/theme/theme.js:277:19)
    at updateStatus (.../extensions/direnv.ts:41:18)
```

Use `error` so the status renders instead of taking down the session.