### PR TITLE
statusline: follow model_select -> model_update event rename

### DIFF
--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -171,7 +171,7 @@ export default function statusline(pi: ExtensionAPI) {
 		}
 	});
 
-	pi.on("model_select" as any, async (_event: any, ctx: ExtensionContext) => {
+	pi.on("model_update" as any, async (_event: any, ctx: ExtensionContext) => {
 		currentCtx = ctx;
 		const provider = currentProvider();
 		if (provider) {


### PR DESCRIPTION
pi-agent-core 0.77.0 renamed the harness events model_select and thinking_level_select to model_update and thinking_level_update. The statusline listened to the old name, so switching models no longer refreshed the model display or usage data on current pi versions.