### PR TITLE
direnv: handle FSWatcher "error" events

### DIFF
--- a/direnv/index.ts
+++ b/direnv/index.ts
@@ -78,30 +78,45 @@ export default function (pi: ExtensionAPI) {
 		if (reloadTimer) clearTimeout(reloadTimer);
 		reloadTimer = setTimeout(() => {
 			reloadTimer = null;
-			if (latestCtx) loadDirenv(latestCtx.cwd, latestCtx);
+			if (!latestCtx) return;
+			loadDirenv(latestCtx.cwd, latestCtx);
+			// Re-arm watchers: one may have died with an "error" event, and
+			// .envrc / .direnv may have appeared since the last arm.
+			startWatchers(latestCtx.cwd);
 		}, RELOAD_DEBOUNCE_MS);
+	}
+
+	function armWatcher(path: string): void {
+		try {
+			const w = watch(path, () => scheduleReload());
+			// FSWatcher emits "error" asynchronously, e.g. when a watched
+			// entry vanishes mid-event (Bun's watcher can hit ENOENT when
+			// nix-direnv replaces its .direnv/flake-profile-* gc root).
+			// Without a listener that becomes an uncaughtException and
+			// takes down the whole agent. Close the dead watcher and
+			// schedule a reload, which also re-arms the watchers.
+			w.on("error", () => {
+				try {
+					w.close();
+				} catch {
+					/* ignore */
+				}
+				scheduleReload();
+			});
+			watchers.push(w);
+		} catch {
+			// path may not exist (yet) — that's fine
+		}
 	}
 
 	function startWatchers(cwd: string): void {
 		stopWatchers();
 
 		// Watch .envrc — covers edits and direnv allow (which rewrites .envrc state)
-		const envrcPath = join(cwd, ".envrc");
-		try {
-			const w = watch(envrcPath, () => scheduleReload());
-			watchers.push(w);
-		} catch {
-			// .envrc may not exist — that's fine
-		}
+		armWatcher(join(cwd, ".envrc"));
 
 		// Watch .direnv/ — covers flake rebuilds, nix develop, direnv allow state
-		const direnvDir = join(cwd, ".direnv");
-		try {
-			const w = watch(direnvDir, () => scheduleReload());
-			watchers.push(w);
-		} catch {
-			// .direnv/ may not exist yet — that's fine
-		}
+		armWatcher(join(cwd, ".direnv"));
 	}
 
 	function stopWatchers(): void {


### PR DESCRIPTION
## Problem

Running pi (a bun binary) in a nix-direnv project can crash the whole agent:

```
pi exiting due to uncaughtException:
ENOENT: no such file or directory, open '/path/to/project/.direnv/flake-profile-<hash>'
    path: ".../.direnv/flake-profile-<hash>",
 syscall: "open",
   errno: -2,
    code: "ENOENT"
```

Bun's fs.watch backend emits an async `error` event on the FSWatcher when a
watched directory entry vanishes between the change event and the follow-up
stat/open. nix-direnv does exactly that when it replaces its
`.direnv/flake-profile-*` gc root on a devshell rebuild. The direnv extension
attaches no `error` listener to its watchers, so the event surfaces as an
uncaughtException and takes down the session.

## Fix

- Attach an `error` handler to each watcher that closes the dead watcher and
  schedules a reload instead of crashing.
- The debounced reload now also re-arms the watchers, so a watcher lost to an
  error is recreated. As a side effect this also picks up `.envrc`/`.direnv`
  created after session start, which previously needed a manual `/direnv`.

## Testing

Verified with a harness that loads the extension with a stubbed ExtensionAPI
and emits `error` on the armed FSWatcher: before this change the process dies
with the uncaughtException above, after it the session survives and the
watchers are re-armed.
