### PR TITLE
statusline: cache failed VCS lookups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
       # a bare checkout has none, so ui.ts cannot resolve @mariozechner/pi-tui.
       # bun install pulls peer deps in by default.
       - run: bun install
-      - run: bun test permission-gate
+      - run: bun test permission-gate statusline

--- a/statusline/src/vcs.test.ts
+++ b/statusline/src/vcs.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, expect, mock, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let spawnCalls = 0;
+
+mock.module("node:child_process", () => ({
+	spawnSync: () => ({}),
+	spawn: () => {
+		spawnCalls++;
+		const proc = new EventEmitter() as EventEmitter & {
+			stdout: EventEmitter;
+			pid: number;
+			exitCode: number | null;
+			signalCode: NodeJS.Signals | null;
+			kill: () => boolean;
+		};
+		proc.stdout = new EventEmitter();
+		proc.pid = 10_000 + spawnCalls;
+		proc.exitCode = null;
+		proc.signalCode = null;
+		proc.kill = () => true;
+		queueMicrotask(() => {
+			proc.exitCode = 1;
+			proc.emit("close", 1);
+		});
+		return proc;
+	},
+}));
+
+const { getVcsStatus, invalidateVcs, setVcsUpdateCallback } = await import("./vcs.ts");
+const tempDir = mkdtempSync(join(tmpdir(), "statusline-vcs-"));
+const repoDir = join(tempDir, "repo");
+mkdirSync(join(repoDir, ".git"), { recursive: true });
+
+afterAll(() => {
+	setVcsUpdateCallback(null);
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("caches a failed VCS lookup until invalidated", async () => {
+	let updates = 0;
+	let resolveFirst!: () => void;
+	const firstUpdate = new Promise<void>((resolve) => {
+		resolveFirst = resolve;
+	});
+	setVcsUpdateCallback(() => {
+		updates++;
+		// Simulate one render requested by the real statusline callback.
+		if (updates === 1) getVcsStatus(repoDir);
+		resolveFirst();
+	});
+
+	expect(getVcsStatus(repoDir)).toBeNull();
+	await firstUpdate;
+
+	expect(updates).toBe(1);
+	expect(spawnCalls).toBe(1);
+
+	invalidateVcs();
+	const secondUpdate = new Promise<void>((resolve) => {
+		setVcsUpdateCallback(() => resolve());
+	});
+	expect(getVcsStatus(repoDir)).toBeNull();
+	await secondUpdate;
+
+	expect(spawnCalls).toBe(2);
+});

--- a/statusline/src/vcs.ts
+++ b/statusline/src/vcs.ts
@@ -101,7 +101,7 @@ async function gitCounts(): Promise<Counts | null> {
 	return { modified, added, removed };
 }
 
-let cachedStatus: VcsStatus | null = null;
+let cachedStatus: VcsStatus | null | undefined;
 let inflight = false;
 let seq = 0;
 let onUpdate: (() => void) | null = null;
@@ -111,7 +111,7 @@ export function setVcsUpdateCallback(cb: (() => void) | null): void {
 }
 
 export function invalidateVcs(): void {
-	cachedStatus = null;
+	cachedStatus = undefined;
 	seq++;
 }
 
@@ -258,7 +258,7 @@ async function fetchVcsStatus(cwd: string): Promise<VcsStatus | null> {
  */
 export function getVcsStatus(cwd: string): VcsStatus | null {
 	if (detectRepo(cwd) === null) return null;
-	if (cachedStatus === null && !inflight) {
+	if (cachedStatus === undefined && !inflight) {
 		inflight = true;
 		const mySeq = seq;
 		void fetchVcsStatus(cwd).then((result) => {
@@ -268,5 +268,5 @@ export function getVcsStatus(cwd: string): VcsStatus | null {
 			onUpdate?.();
 		});
 	}
-	return cachedStatus;
+	return cachedStatus ?? null;
 }


### PR DESCRIPTION
## Summary

- distinguish an unfetched VCS status from a completed lookup that returned no status
- cache failed/empty lookups until the next explicit `invalidateVcs()`
- add a deterministic regression test and include statusline tests in CI

## Problem

`cachedStatus` previously used `null` for both “not fetched” and “the lookup returned no status”. When a Git or jj command failed, the async lookup stored `null` and invoked the statusline update callback. That callback requested a render, and the next `getVcsStatus()` call interpreted the same `null` as a cache miss and immediately launched another subprocess. Persistent command failures therefore caused an unbounded subprocess/render loop.

## Fix

Use a tri-state cache:

- `undefined`: no lookup has completed since startup or invalidation
- `null`: a lookup completed without a status
- `VcsStatus`: a lookup completed successfully

Only `undefined` starts a fetch, and `invalidateVcs()` restores that state. The public return type remains `VcsStatus | null`.

The regression test mocks a failing VCS subprocess, simulates the render callback, verifies that no second lookup starts, and verifies that explicit invalidation permits one new lookup. The same test fails against `main` with two subprocess calls instead of one.

## Verification

- `bun test statusline/src/vcs.test.ts`
- `node --experimental-transform-types --check statusline/src/vcs.ts`
- `node --experimental-transform-types --check statusline/src/vcs.test.ts`
