### PR TITLE
statusline: prevent host crash from stale ctx in usage refresh timer

### DIFF
--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -42,12 +42,24 @@ export default function statusline(pi: ExtensionAPI) {
 	}
 
 	function currentProvider() {
-		return detectProvider(currentCtx?.model);
+		try {
+			return detectProvider(currentCtx?.model);
+		} catch {
+			// ctx is stale after session replacement/reload; drop it and wait
+			// for the next session_start/model_update to re-set it.
+			currentCtx = undefined;
+			return undefined;
+		}
 	}
 
 	// ── Widget (single line below editor) ────────────────────────────────
 
 	function renderWidget(): void {
+		try {
+			if (currentCtx) void currentCtx.model; // stale probe: throws if replaced
+		} catch {
+			currentCtx = undefined;
+		}
 		if (!currentCtx || !enabled || !settings.showBar) {
 			currentCtx?.ui.setWidget("statusline-bar", undefined);
 			return;

--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -108,7 +108,17 @@ export default function statusline(pi: ExtensionAPI) {
 
 	async function initUsage(ctx: ExtensionContext): Promise<void> {
 		if (ctx.modelRegistry?.getApiKeyForProvider) {
-			setApiKeyResolver((provider) => ctx.modelRegistry.getApiKeyForProvider(provider));
+			// ctx.modelRegistry's getter throws once ctx is stale after session
+			// replacement; this closure is invoked from timer/turn_end-driven
+			// usage refreshes long after that. Fail soft to the auth.json
+			// fallback instead of propagating (a fresh ctx re-registers here).
+			setApiKeyResolver((provider) => {
+				try {
+					return ctx.modelRegistry.getApiKeyForProvider(provider);
+				} catch {
+					return undefined;
+				}
+			});
 		}
 
 		const provider = currentProvider();
@@ -158,7 +168,7 @@ export default function statusline(pi: ExtensionAPI) {
 	pi.on("turn_end", async () => {
 		const provider = currentProvider();
 		if (provider) {
-			void usage.refresh(provider);
+			usage.refresh(provider).catch(() => {});
 		}
 	});
 
@@ -187,7 +197,7 @@ export default function statusline(pi: ExtensionAPI) {
 		currentCtx = ctx;
 		const provider = currentProvider();
 		if (provider) {
-			void usage.refresh(provider);
+			usage.refresh(provider).catch(() => {});
 		}
 		renderWidget();
 		tuiRef?.requestRender();
@@ -213,7 +223,7 @@ export default function statusline(pi: ExtensionAPI) {
 				if (enabled) {
 					setupFooter(ctx);
 					const provider = currentProvider();
-					if (provider) void usage.refresh(provider);
+					if (provider) usage.refresh(provider).catch(() => {});
 					usage.start(currentProvider);
 					renderWidget();
 					ctx.ui.notify("Statusline enabled", "info");
@@ -253,7 +263,17 @@ export default function statusline(pi: ExtensionAPI) {
 
 			if (arg === "refresh") {
 				if (ctx.modelRegistry?.getApiKeyForProvider) {
-					setApiKeyResolver((provider) => ctx.modelRegistry.getApiKeyForProvider(provider));
+					// ctx.modelRegistry's getter throws once ctx is stale after session
+					// replacement; this closure is invoked from timer/turn_end-driven
+					// usage refreshes long after that. Fail soft to the auth.json
+					// fallback instead of propagating (a fresh ctx re-registers here).
+					setApiKeyResolver((provider) => {
+						try {
+							return ctx.modelRegistry.getApiKeyForProvider(provider);
+						} catch {
+							return undefined;
+						}
+					});
 				}
 				resetRateLimit();
 				const provider = currentProvider();

--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -216,6 +216,11 @@ export default function statusline(pi: ExtensionAPI) {
 		currentCtx = undefined;
 		tuiRef = null;
 		setVcsUpdateCallback(null);
+		// The resolver closes over this session's ctx but lives in providers.ts,
+		// which the next session shares. Drop it so that session falls back to
+		// auth.json until its own session_start rebinds, instead of calling
+		// into a disposed ctx (bindApiKeyResolver only makes that harmless).
+		setApiKeyResolver(undefined);
 	});
 
 	// ── Command ──────────────────────────────────────────────────────────

--- a/statusline/index.ts
+++ b/statusline/index.ts
@@ -52,6 +52,26 @@ export default function statusline(pi: ExtensionAPI) {
 		}
 	}
 
+	/**
+	 * Route usage fetches through this session's model registry so they use
+	 * pi's auto-refreshed OAuth token rather than a possibly-stale auth.json.
+	 *
+	 * The closure is stored module-level in providers.ts and invoked from
+	 * timers and turn_end, so it outlives the session that created it; every
+	 * ctx getter throws once that session is replaced. Fail soft to the
+	 * auth.json fallback instead of letting the throw reach the host.
+	 */
+	function bindApiKeyResolver(ctx: ExtensionContext): void {
+		if (!ctx.modelRegistry?.getApiKeyForProvider) return;
+		setApiKeyResolver(async (provider) => {
+			try {
+				return await ctx.modelRegistry.getApiKeyForProvider(provider);
+			} catch {
+				return undefined;
+			}
+		});
+	}
+
 	// ── Widget (single line below editor) ────────────────────────────────
 
 	function renderWidget(): void {
@@ -107,19 +127,7 @@ export default function statusline(pi: ExtensionAPI) {
 	// ── Init usage fetch ─────────────────────────────────────────────────
 
 	async function initUsage(ctx: ExtensionContext): Promise<void> {
-		if (ctx.modelRegistry?.getApiKeyForProvider) {
-			// ctx.modelRegistry's getter throws once ctx is stale after session
-			// replacement; this closure is invoked from timer/turn_end-driven
-			// usage refreshes long after that. Fail soft to the auth.json
-			// fallback instead of propagating (a fresh ctx re-registers here).
-			setApiKeyResolver((provider) => {
-				try {
-					return ctx.modelRegistry.getApiKeyForProvider(provider);
-				} catch {
-					return undefined;
-				}
-			});
-		}
+		bindApiKeyResolver(ctx);
 
 		const provider = currentProvider();
 		if (provider) {
@@ -262,19 +270,7 @@ export default function statusline(pi: ExtensionAPI) {
 			}
 
 			if (arg === "refresh") {
-				if (ctx.modelRegistry?.getApiKeyForProvider) {
-					// ctx.modelRegistry's getter throws once ctx is stale after session
-					// replacement; this closure is invoked from timer/turn_end-driven
-					// usage refreshes long after that. Fail soft to the auth.json
-					// fallback instead of propagating (a fresh ctx re-registers here).
-					setApiKeyResolver((provider) => {
-						try {
-							return ctx.modelRegistry.getApiKeyForProvider(provider);
-						} catch {
-							return undefined;
-						}
-					});
-				}
+				bindApiKeyResolver(ctx);
 				resetRateLimit();
 				const provider = currentProvider();
 				if (provider) {

--- a/statusline/src/providers.test.ts
+++ b/statusline/src/providers.test.ts
@@ -1,15 +1,18 @@
-import { afterAll, afterEach, beforeEach, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import * as os from "node:os";
 import { join } from "node:path";
 
 // providers.ts consults a shared on-disk usage cache (and rate-limit file)
-// before fetching. Point it at an empty dir *before import*, otherwise a fresh
-// cache.json written by a real pi session on this machine short-circuits
-// refresh() before it ever reaches the resolver under test -- and the test
-// would pass or fail depending on whether pi happened to be running.
-const configHome = mkdtempSync(join(tmpdir(), "statusline-providers-"));
+// before fetching, and falls back to ~/.pi/agent/auth.json for credentials.
+// Point both at an empty dir *before import*: otherwise a fresh cache.json
+// from a live pi session short-circuits refresh() before it reaches the
+// resolver under test, and a real auth.json would turn the fallback path
+// into a network call. homedir() is mocked rather than setting $HOME because
+// Bun resolves os.homedir() once at startup and ignores later env changes.
+const configHome = mkdtempSync(join(os.tmpdir(), "statusline-providers-"));
 process.env.XDG_CONFIG_HOME = configHome;
+mock.module("node:os", () => ({ ...os, homedir: () => configHome }));
 
 const { createUsageController, setApiKeyResolver } = await import("./providers.ts");
 
@@ -39,7 +42,7 @@ afterEach(() => {
 });
 
 afterAll(() => {
-	setApiKeyResolver(async () => undefined);
+	setApiKeyResolver(undefined);
 	rmSync(configHome, { recursive: true, force: true });
 });
 
@@ -63,6 +66,21 @@ test("refresh() resolves to the last snapshot when the API-key resolver throws (
 	const usage = createUsageController(() => {});
 	// Throws before any network I/O: loadAnthropicToken awaits the resolver first.
 	await expect(usage.refresh("anthropic")).resolves.toBeUndefined();
+});
+
+// What session_shutdown now does. The next session must not reach the old
+// closure at all; with no resolver and no auth.json (HOME is empty) the fetch
+// reports missing credentials without touching the network.
+test("a cleared resolver is not invoked; refresh falls back to auth.json", async () => {
+	let calls = 0;
+	setApiKeyResolver(async () => {
+		calls++;
+		return stale();
+	});
+	setApiKeyResolver(undefined);
+	const usage = createUsageController(() => {});
+	await expect(usage.refresh("anthropic")).resolves.toBeUndefined();
+	expect(calls).toBe(0);
 });
 
 // Same rejection, reached from the timer instead of an event handler:

--- a/statusline/src/providers.test.ts
+++ b/statusline/src/providers.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, afterEach, beforeEach, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// providers.ts consults a shared on-disk usage cache (and rate-limit file)
+// before fetching. Point it at an empty dir *before import*, otherwise a fresh
+// cache.json written by a real pi session on this machine short-circuits
+// refresh() before it ever reaches the resolver under test -- and the test
+// would pass or fail depending on whether pi happened to be running.
+const configHome = mkdtempSync(join(tmpdir(), "statusline-providers-"));
+process.env.XDG_CONFIG_HOME = configHome;
+
+const { createUsageController, setApiKeyResolver } = await import("./providers.ts");
+
+// What pi's ExtensionRunner throws from every ctx getter once the session that
+// produced the ctx has been replaced (/new, /resume, /fork) and disposed.
+const stale = () => {
+	throw new Error("This extension ctx is stale after session replacement or reload.");
+};
+
+// Capture the interval callback instead of waiting 10s for a real tick.
+const realSetInterval = globalThis.setInterval;
+const realClearInterval = globalThis.clearInterval;
+let ticks: Array<() => void> = [];
+
+beforeEach(() => {
+	ticks = [];
+	(globalThis as any).setInterval = (fn: () => void) => {
+		ticks.push(fn);
+		return ticks.length;
+	};
+	(globalThis as any).clearInterval = () => {};
+});
+
+afterEach(() => {
+	globalThis.setInterval = realSetInterval;
+	globalThis.clearInterval = realClearInterval;
+});
+
+afterAll(() => {
+	setApiKeyResolver(async () => undefined);
+	rmSync(configHome, { recursive: true, force: true });
+});
+
+// The tick runs from Timeout._onTimeout, outside any host try/catch, so a
+// throw here is an uncaughtException and pi exits. index.ts passes
+// currentProvider as getProvider, which reads currentCtx.model.
+test("timer tick swallows a getProvider that throws (stale ctx.model)", () => {
+	const usage = createUsageController(() => {});
+	usage.start(stale as never);
+	expect(ticks).toHaveLength(1);
+	expect(() => ticks[0]!()).not.toThrow();
+	usage.stop();
+});
+
+// The resolver closure captures ctx at session_start; the module (and this
+// variable) outlives that session because pi caches the extension factory
+// and re-runs it per session without re-importing. Every `void usage.refresh()`
+// call site turned this rejection into an unhandledRejection.
+test("refresh() resolves to the last snapshot when the API-key resolver throws (stale ctx.modelRegistry)", async () => {
+	setApiKeyResolver(async () => stale());
+	const usage = createUsageController(() => {});
+	// Throws before any network I/O: loadAnthropicToken awaits the resolver first.
+	await expect(usage.refresh("anthropic")).resolves.toBeUndefined();
+});
+
+// Same rejection, reached from the timer instead of an event handler:
+// first tick has lastFetchAt=0, so it always attempts a refresh.
+test("tick-driven refresh failure does not surface as an unhandledRejection", async () => {
+	setApiKeyResolver(async () => stale());
+	let unhandled = 0;
+	const onUnhandled = () => void unhandled++;
+	process.on("unhandledRejection", onUnhandled);
+	try {
+		const usage = createUsageController(() => {});
+		usage.start(() => "anthropic");
+		ticks[0]!();
+		await new Promise((r) => setTimeout(r, 20));
+		expect(unhandled).toBe(0);
+		usage.stop();
+	} finally {
+		process.off("unhandledRejection", onUnhandled);
+	}
+});

--- a/statusline/src/providers.ts
+++ b/statusline/src/providers.ts
@@ -302,21 +302,28 @@ export function createUsageController(onUpdate: (usage: UsageSnapshot | undefine
 	let lastFetchAt = 0;
 
 	async function doRefresh(provider: ProviderName): Promise<UsageSnapshot | undefined> {
-		const promise = fetchUsage(provider);
-		if (!promise) {
-			cached = undefined;
-			onUpdate(undefined);
-			return undefined;
+		// Usage refresh is background telemetry: no failure in here (stale
+		// ctx, network error, parse error) should ever propagate into the
+		// host's event loop. Degrade to the last cached snapshot instead.
+		try {
+			const promise = fetchUsage(provider);
+			if (!promise) {
+				cached = undefined;
+				onUpdate(undefined);
+				return undefined;
+			}
+			const result = await promise;
+			lastFetchAt = Date.now();
+			if (result.windows.length > 0) {
+				cached = result;
+			} else if (cached?.provider !== provider) {
+				cached = undefined;
+			}
+			onUpdate(cached);
+			return cached;
+		} catch {
+			return cached;
 		}
-		const result = await promise;
-		lastFetchAt = Date.now();
-		if (result.windows.length > 0) {
-			cached = result;
-		} else if (cached?.provider !== provider) {
-			cached = undefined;
-		}
-		onUpdate(cached);
-		return cached;
 	}
 
 	return {

--- a/statusline/src/providers.ts
+++ b/statusline/src/providers.ts
@@ -351,11 +351,15 @@ export function createUsageController(onUpdate: (usage: UsageSnapshot | undefine
 			if (timer) clearInterval(timer);
 			const tickMs = Math.min(REFRESH_INTERVAL_S * 1000, 10_000);
 			timer = setInterval(() => {
-				const p = getProvider();
-				if (!p) return;
-				const elapsed = Date.now() - lastFetchAt;
-				if (elapsed >= REFRESH_INTERVAL_S * 1000) {
-					void doRefresh(p);
+				try {
+					const p = getProvider();
+					if (!p) return;
+					const elapsed = Date.now() - lastFetchAt;
+					if (elapsed >= REFRESH_INTERVAL_S * 1000) {
+						doRefresh(p).catch(() => {});
+					}
+				} catch {
+					// never let a timer tick crash the host process
 				}
 			}, tickMs);
 		},

--- a/statusline/src/providers.ts
+++ b/statusline/src/providers.ts
@@ -14,6 +14,10 @@ import { fetchWithCache, getCached, isRateLimited, setRateLimited, writeCachedUs
  * Resolver for live API keys from pi's model registry.
  * Set by the extension on session_start so providers use
  * the auto-refreshed OAuth token instead of the stale auth.json.
+ *
+ * Module-level, and pi re-runs the extension factory per session without
+ * re-importing this module, so whatever is stored here survives session
+ * replacement. The owning session must clear it on session_shutdown.
  */
 let apiKeyResolver: ((provider: string) => Promise<string | undefined>) | undefined;
 
@@ -92,7 +96,7 @@ const DETECTION: Array<{ provider: ProviderName; providerTokens: string[]; model
 	{ provider: "codex", providerTokens: ["openai", "codex"], modelTokens: ["gpt", "o1", "o3", "codex"] },
 ];
 
-export function setApiKeyResolver(resolver: (provider: string) => Promise<string | undefined>): void {
+export function setApiKeyResolver(resolver: ((provider: string) => Promise<string | undefined>) | undefined): void {
 	apiKeyResolver = resolver;
 }
 


### PR DESCRIPTION
## Problem

The statusline's usage refresh timer can crash the entire pi process. `usage.start(currentProvider)` arms a `setInterval` whose tick calls `currentProvider()` → `detectProvider(currentCtx?.model)`. After a session replacement or reload (`ctx.newSession()`, `ctx.fork()`, `ctx.switchSession()`, `ctx.reload()`), the captured `currentCtx` is stale and its getters throw. The extension re-captures a ctx on `session_start`/`model_update`, but the timer can fire inside the replacement window — and because the tick runs from `Timeout._onTimeout`, outside the host's guarded extension call path, the throw escapes as an `uncaughtException` and pi exits:

```
pi exiting due to uncaughtException:
Error: This extension ctx is stale after session replacement or reload. ...
    at ExtensionRunner.assertActive (.../core/extensions/runner.js:360:19)
    at get model (.../core/extensions/runner.js:489:24)
    at currentProvider (.../statusline/index.ts:45:53)
    at Timeout._onTimeout (.../statusline/src/providers.ts:354:19)
```

(The `/statusline` command handler also stashes a command ctx into `currentCtx`, which goes stale as soon as the command ends — same class.)

## Fix

Guard every path a timer tick can reach, so a stale tick degrades to a skipped refresh instead of killing the host:

- `currentProvider()`: try/catch; on stale ctx, clear `currentCtx` and return `undefined` (the next `session_start`/`model_update` re-sets it)
- `renderWidget()`: probe `currentCtx` for staleness before use — it touches `currentCtx.ui` and is reachable from the timer via the usage controller's `onUpdate` callback
- interval body: wrapped in try/catch so no sync throw can escape the timer
- `doRefresh(p).catch(() => {})` instead of `void doRefresh(p)`, so a rejected refresh (e.g. network timeout) can't become an `unhandledRejection`

No behavior change in the normal path; existing tests (vcs) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
