### PR TITLE
nushell: run the bash tool through Nushell, gated by permission-gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       # a bare checkout has none, so ui.ts cannot resolve @mariozechner/pi-tui.
       # bun install pulls peer deps in by default.
       - run: bun install
+      - uses: hustcer/setup-nu@v3
       # slow-mode's tests pin PI_SLOW_MODE_DIFF=builtin, so they do not need
       # difftastic or delta on the runner.
-      - run: bun test permission-gate statusline slow-mode
+      - run: bun test permission-gate statusline slow-mode nushell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ This is **pi-agent-extensions** — a collection of [pi](https://github.com/mari
 | `permission-gate/` | Prompt or block dangerous bash commands (regex or tokenized-argv rules) |
 | `statusline/` | Condensed status bar: model, usage, context, VCS (git/jj), cost |
 | `direnv/` | Loads direnv environment variables on session start and after bash commands |
+| `nushell/` | Runs the `bash` tool through Nushell and gates it with permission-gate's rules via nu's parser (supersedes loading `permission-gate/` directly) |
 | `fetch/` | HTTP request tool — fetches URLs, downloads files, shows curl equivalent |
 | `questionnaire/` | Multi-question tool for LLM-driven user input |
 | `slow-mode/` | Review gate for write/edit tool calls — toggle with `/slow-mode` |

--- a/README.org
+++ b/README.org
@@ -575,6 +575,20 @@ Errors show with red background:
 #+html:</details>
 
 #+html:<details>
+#+html:<summary><strong>nushell</strong> - run the <code>bash</code> tool through Nushell, gated by permission-gate rules</summary>
+#+html:<br>
+
+- *Source*: [[https://github.com/rytswd/pi-agent-extensions/tree/main/nushell][nushell/]]
+- *License*: MIT
+- *Requirements*: =nu= in =PATH=; without it the extension behaves exactly like =permission-gate=
+
+Re-registers pi's =bash= tool with =nu= as the interpreter (=createBashTool= with =shellPath=), so streaming, tail truncation, timeouts and abort handling are unchanged; the tool description and prompt guidelines tell the model it is writing Nushell. If =$XDG_CONFIG_HOME/nushell/pi.nu= exists it is sourced before every script.
+
+Includes =permission-gate= (same =/gate= command, config files, rules and events — load this /or/ =permission-gate=, not both) with a different parser: the script is tokenized by =nu= itself (=ast --flatten=) and mapped onto argv pipelines — commands inside closures, =( )= subexpressions, =if=/=def= bodies, =^external= and =run-external= included. =sh -c= strings recurse into the POSIX parser, =nu -c= strings into the nu one. Scripts nu cannot parse, or whose command name only exists at runtime (=^$cmd=), count as unverified and prompt (block when headless).
+
+#+html:</details>
+
+#+html:<details>
 #+html:<summary><strong>direnv</strong> - Auto-loads environment variables from <code>.envrc</code> files</summary>
 #+html:<br>
 

--- a/nushell/ast.test.ts
+++ b/nushell/ast.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Run with: bun test nushell   (needs `nu` in PATH; skipped otherwise)
+ */
+import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { hasOpaqueCommand, NU_VALUE, nuPipelines, OPAQUE_HEAD } from "./ast.ts";
+import { tokenize } from "./gate.ts";
+
+const hasNu = (() => {
+	try { execFileSync("nu", ["--version"]); return true; } catch { return false; }
+})();
+
+const pipes = async (script: string) => nuPipelines(script, await tokenize(script));
+
+describe.skipIf(!hasNu)("nuPipelines", () => {
+	test("built-in command with flags and args", async () => {
+		expect(await pipes("rm -rf foo")).toEqual([[["rm", "-rf", "-rf", "foo"]]]);
+	});
+
+	test("statements split on ; and newline, pipes join", async () => {
+		expect(await pipes("ls | length; echo a\necho b")).toEqual([
+			[["ls"], ["length"]],
+			[["echo", "a"]],
+			[["echo", "b"]],
+		]);
+	});
+
+	test("externals inside closures and subexpressions are found", async () => {
+		const p = await pipes('ls | each {|f| ^rm -rf $f.name }; let x = (git push --force o main)');
+		expect(p).toContainEqual([["rm", "-rf", "$f", "name"]]);
+		expect(p).toContainEqual([["git", "push", "--force", "o", "main"]]);
+		expect(p).toContainEqual([["ls"], ["each", "{...}"]]);
+	});
+
+	test("if/else and def bodies", async () => {
+		const p = await pipes("def f [] { rm y }; if true { mv a b } else { cp a b }");
+		expect(p).toContainEqual([["rm", "y"]]);
+		expect(p).toContainEqual([["mv", "a", "b"]]);
+		expect(p).toContainEqual([["cp", "a", "b"]]);
+	});
+
+	test("quoted strings are unquoted so nested sh scripts can be recursed", async () => {
+		expect(await pipes(`bash -c "sudo id" o> f`)).toEqual([[["bash", "-c", "sudo id"]]]);
+	});
+
+	test("run-external exposes the wrapped argv", async () => {
+		expect(await pipes("run-external rm q")).toEqual([[["run-external", "rm", "q"], ["rm", "q"]]]);
+	});
+
+	test("unresolvable head is opaque", async () => {
+		const p = await pipes("let cmd = 'x'; ^$cmd arg");
+		expect(p).toEqual([[["let", "x"]], [[OPAQUE_HEAD, "arg"]]]);
+		expect(hasOpaqueCommand(p)).toBe(true);
+		for (const s of ['^$"r("m")" x', "ls | ^ $in"]) {
+			expect({ s, opaque: hasOpaqueCommand(await pipes(s)) }).toEqual({ s, opaque: true });
+		}
+		expect(hasOpaqueCommand(await pipes("^git status; echo $env.PWD; [1] | each {|x| echo $x }"))).toBe(false);
+	});
+
+	test("spans are byte offsets: non-ASCII before a `;` must not hide the next command", async () => {
+		expect(await pipes('echo "ää€"; sudo id')).toEqual([[["echo", "ää€"]], [["sudo", "id"]]]);
+	});
+
+	test("a pipe across a newline is one pipeline", async () => {
+		expect(await pipes("curl x\n| bash")).toEqual([[["curl", "x"], ["bash"]]]);
+		expect(await pipes("curl x |\nbash")).toEqual([[["curl", "x"], ["bash"]]]);
+	});
+
+	test("stderr pipe redirect `e>|` has no target to skip", async () => {
+		expect(await pipes("foo e>| sudo id")).toEqual([[["foo"], ["sudo", "id"]]]);
+		expect(await pipes("ls out> /dev/null | sudo id")).toEqual([[["ls"], ["sudo", "id"]]]);
+	});
+
+	test("a `^` inside a comment does not make the next command opaque", async () => {
+		expect(await pipes("# see ^\nls")).toEqual([[["ls"]]]);
+	});
+
+	test("string interpolation is one opaque word, its subexpressions are still collected", async () => {
+		const p = await pipes('^bash -c $"sudo (id) x"');
+		expect(p).toContainEqual([["bash", "-c", "${nu}"]]);
+		expect(p).toContainEqual([["id"]]);
+	});
+
+	test("single-token closures do not open a frame that never closes", async () => {
+		expect(await pipes("each {|| }; ls | length")).toEqual([[["each", "{...}"]], [["ls"], ["length"]]]);
+		expect(await pipes("do {}; ^sudo id")).toEqual([[["do", "{...}"]], [["sudo", "id"]]]);
+	});
+
+	test("quoted external names are unquoted", async () => {
+		expect(await pipes("`sudo` id")).toEqual([[["sudo", "id"]]]);
+		expect(await pipes("^'sudo' id")).toEqual([[["sudo", "id"]]]);
+		expect(await pipes(`^"my tool" x`)).toEqual([[["my tool", "x"]]]);
+	});
+
+	test("a bare value is a pipeline stage feeding stdin", async () => {
+		expect(await pipes("[a b] | each { touch $in }")).toEqual([
+			[["touch", "$in"]],
+			[[NU_VALUE, "a", "b"], ["each", "{...}"]],
+		]);
+		expect(await pipes("'sudo id' | ^sh")).toEqual([[[NU_VALUE, "sudo id"], ["sh"]]]);
+	});
+});

--- a/nushell/ast.ts
+++ b/nushell/ast.ts
@@ -1,0 +1,183 @@
+/**
+ * nushell — map nu's `ast --flatten` tokens onto permission-gate pipelines.
+ *
+ * nu classifies every token for us (internal/external call, flag, string,
+ * block delimiter, …). --flatten loses only two things, recovered here:
+ *   - statement boundaries: read from the source text between two tokens
+ *   - nesting: tracked from the `{ … }`, `( … )`, `$" … "` delimiter tokens
+ * Each nested body yields its own pipelines, like permission-gate treats
+ * `$( … )` in sh.
+ */
+
+import type { ArgvPipeline } from "../permission-gate/types.ts";
+
+export interface FlatToken {
+	content: string;
+	shape: string;
+	/** UTF-8 byte offsets into the script. */
+	span: { start: number; end: number };
+}
+
+/** argv[0] when the command name only exists at runtime (`^$cmd`, `^ $in`). */
+export const OPAQUE_HEAD = "\0nu-opaque-command";
+
+/**
+ * argv[0] of a stage that is a bare value (`'sudo id' | ^sh`). It runs
+ * nothing but feeds stdin, so it must occupy a stage for pipeline rules
+ * ("shell executes stdin") to see `sh` as downstream.
+ */
+export const NU_VALUE = "\0nu-value";
+
+/**
+ * Stand-in word for a value computed at runtime (`$"…"`). Spelled as a sh
+ * parameter expansion so that, forwarded into `bash -c`, permission-gate's
+ * "non-literal command name" rule recognises it.
+ */
+const RUNTIME_WORD = "${nu}";
+
+/** Punctuation and declarations that never become an argv word. */
+const SYNTAX_SHAPES = new Set([
+	"shape_operator", "shape_keyword", "shape_pipe", "shape_match_pattern",
+	"shape_list", "shape_record", "shape_table", "shape_signature", "shape_vardecl",
+]);
+
+/** `run-external rm x` runs `rm x`. */
+const WRAPPERS = new Set(["run-external", "exec"]);
+/** nu built-ins behaving like a POSIX tool the rules already know. */
+const ALIASES: Record<string, string> = { save: "tee" };
+
+function unquote(s: string): string {
+	const raw = /^r(#+)'([\s\S]*)'\1$/.exec(s); // r#'…'#
+	if (raw) return raw[2];
+	return /^(["'`])[\s\S]*\1$/.test(s) ? s.slice(1, -1) : s;
+}
+
+/** Also list the command a wrapper/alias stands for, right after it. */
+function expandWrappers(pipeline: ArgvPipeline): ArgvPipeline {
+	return pipeline.flatMap((argv) => {
+		const [head, ...rest] = argv;
+		if (WRAPPERS.has(head) && rest.length) return [argv, rest];
+		if (head in ALIASES) return [argv, [ALIASES[head], ...rest]];
+		return [argv];
+	});
+}
+
+/** One `{ }` / `( )` / `$" "` nesting level while walking the tokens. */
+interface Frame {
+	pipeline: ArgvPipeline;
+	/** Command being collected; null between commands. */
+	argv: string[] | null;
+	/** Inside `$"…"`: literal fragments are not words. */
+	interpolation: boolean;
+}
+
+export function nuPipelines(script: string, tokens: FlatToken[]): ArgvPipeline[] {
+	const source = Buffer.from(script);
+	const pipelines: ArgvPipeline[] = [];
+	const stack: Frame[] = [];
+	let frame!: Frame;
+
+	const open = (interpolation = false) => {
+		frame = { pipeline: [], argv: null, interpolation };
+		stack.push(frame);
+	};
+	const endCommand = () => {
+		if (frame.argv?.length) frame.pipeline.push(frame.argv);
+		frame.argv = null;
+	};
+	const endPipeline = () => {
+		endCommand();
+		if (frame.pipeline.length) pipelines.push(expandWrappers(frame.pipeline));
+		frame.pipeline = [];
+	};
+	const close = () => {
+		endPipeline();
+		if (stack.length > 1) stack.pop();
+		frame = stack[stack.length - 1];
+	};
+	const startCommand = (argv0: string[]) => {
+		endCommand();
+		frame.argv = argv0;
+	};
+	const addWord = (word: string) => {
+		if (frame.interpolation) return;
+		frame.argv ??= [NU_VALUE];
+		frame.argv.push(word);
+	};
+
+	open();
+	let cursor = 0;
+	let afterPipe = false;
+	let afterCaret = false; // `^`: the next token is an external command name
+	let afterRedirect = false; // the next token is a redirection target
+
+	for (const token of tokens) {
+		const between = source.subarray(cursor, token.span.start).toString();
+		cursor = token.span.end;
+		const isPipe = token.shape === "shape_pipe";
+		if (/[;\n]/.test(between) && !afterPipe && !isPipe) endPipeline();
+		if (/\^\s*$/.test(between)) afterCaret = true;
+		afterPipe = isPipe;
+
+		if (afterRedirect) {
+			afterRedirect = false;
+			continue;
+		}
+		const text = token.content.trim();
+
+		switch (token.shape) {
+			case "shape_block":
+			case "shape_closure":
+				// "{ ", "{|row| ", "(", "(^", " }", ")", "{}" or a lone "^"
+				if (text.endsWith("^")) afterCaret = true;
+				if (text === "^") continue;
+				if ("({".includes(text[0])) {
+					addWord(text[0] === "(" ? "$(...)" : "{...}");
+					if (!/[)}]$/.test(text)) open();
+				} else {
+					close();
+				}
+				continue;
+
+			case "shape_string_interpolation":
+				// `$"` opens, `"` closes
+				if (text.startsWith("$")) {
+					addWord(RUNTIME_WORD);
+					open(true);
+				} else {
+					close();
+				}
+				continue;
+
+			case "shape_internalcall":
+				afterCaret = false;
+				startCommand(text.split(/\s+/)); // "str trim" is one token
+				continue;
+
+			case "shape_external":
+				afterCaret = false;
+				startCommand(text ? [unquote(text)] : [OPAQUE_HEAD]); // `^ $in` has an empty name
+				continue;
+
+			case "shape_redirection":
+				afterRedirect = true;
+				continue;
+		}
+
+		if (afterCaret) {
+			// `^$cmd`, `^("r" + "m")`: something runs, name unknown
+			afterCaret = false;
+			startCommand([OPAQUE_HEAD]);
+		} else if (!SYNTAX_SHAPES.has(token.shape)) {
+			const quoted = token.shape === "shape_string" || token.shape === "shape_externalarg";
+			addWord(quoted ? unquote(token.content) : token.content);
+		}
+	}
+	while (stack.length > 1) close();
+	endPipeline();
+	return pipelines;
+}
+
+export function hasOpaqueCommand(pipelines: ArgvPipeline[]): boolean {
+	return pipelines.some((p) => p.some((argv) => argv[0] === OPAQUE_HEAD));
+}

--- a/nushell/gate.test.ts
+++ b/nushell/gate.test.ts
@@ -1,0 +1,77 @@
+/**
+ * permission-gate with the nu analyzer applies the built-in rules to nu scripts,
+ * headless (prompt rules hard-block). Run with: bun test nushell (needs nu)
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createGate } from "../permission-gate/index.ts";
+import { analyzeNu } from "./gate.ts";
+
+const hasNu = (() => {
+	try { execFileSync("nu", ["--version"]); return true; } catch { return false; }
+})();
+
+describe.skipIf(!hasNu)("nushell gate (headless)", () => {
+	const env = { ...process.env };
+	let xdg: string;
+	let run: (command: string, toolName?: string) => Promise<unknown>;
+
+	beforeAll(async () => {
+		delete process.env.PI_NO_GATE;
+		process.env.XDG_CONFIG_HOME = xdg = fs.mkdtempSync(path.join(os.tmpdir(), "nugate-"));
+		const handlers: Record<string, (e: unknown, c: unknown) => Promise<unknown>> = {};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		createGate({ on: (n: string, fn: any) => { handlers[n] = fn; }, events: { on: () => () => {}, emit() {} }, registerCommand() {} } as any, analyzeNu("nu"));
+		const ctx = { hasUI: false, cwd: xdg };
+		await handlers.session_start({}, ctx);
+		run = (command, toolName = "bash") => handlers.tool_call({ toolName, input: { command } }, ctx);
+	});
+	afterAll(() => {
+		process.env = env;
+		fs.rmSync(xdg, { recursive: true, force: true });
+	});
+
+	const blocked = (s: string | RegExp) => ({ block: true, reason: typeof s === "string" ? expect.stringContaining(s) : expect.stringMatching(s) });
+
+	test("harmless script passes", async () => {
+		expect(await run("ls | where size > 1kb | get name | to nuon")).toBeUndefined();
+	});
+	test("ignores other tools", async () => {
+		expect(await run("sudo id", "nushell")).toBeUndefined();
+	});
+	test("built-in rm -r fires the recursive delete rule", async () => {
+		expect(await run("rm -r build")).toEqual(blocked("recursive"));
+	});
+	test("external inside closure is seen", async () => {
+		expect(await run("ls | each {|f| ^sudo rm $f.name }")).toEqual(blocked("sudo"));
+	});
+	test("sh -c strings recurse into the POSIX parser", async () => {
+		expect(await run(`bash -c "git push --force origin main"`)).toEqual(blocked(/force/i));
+	});
+	test("nu -c strings recurse into the nu parser", async () => {
+		expect(await run(`nu -c 'ls | each { ^sudo id }'`)).toEqual(blocked("sudo"));
+	});
+	test("nu -c=/--commands= forms recurse too", async () => {
+		expect(await run(`^nu -c='^sudo id'`)).toEqual(blocked("sudo"));
+		expect(await run(`^nu --commands "^sudo id"`)).toEqual(blocked("sudo"));
+	});
+	test("string piped into a bare shell", async () => {
+		expect(await run("'sudo id' | ^sh")).toEqual(blocked("stdin"));
+		expect(await run("[1 2] | each { $in + 1 } | to json | ^jq .")).toBeUndefined();
+	});
+	test("runtime-built command name is unverified", async () => {
+		expect(await run("let c = 'rm'; ^$c -rf /")).toEqual(blocked("unverified"));
+	});
+	test("interpolated sh -c script is a non-literal command", async () => {
+		expect(await run('^bash -c $"sudo (id)"')).toEqual(blocked("non-literal"));
+	});
+	test("save to a raw device maps onto the device-write rule", async () => {
+		expect(await run("open --raw img | save -f /dev/sda")).toEqual(blocked(/device/i));
+	});
+	test("parse errors are unverified", async () => {
+		expect(await run("ls | each {|| ")).toEqual(blocked("nu parse failed"));
+	});
+});

--- a/nushell/gate.ts
+++ b/nushell/gate.ts
@@ -1,0 +1,73 @@
+/**
+ * nushell — permission-gate analyzer backed by nu's own parser.
+ *
+ * Scripts handed on to another interpreter are followed: `sh -c '…'` (and
+ * eval, find -exec, pueue add, …) into permission-gate's POSIX parser,
+ * `nu -c '…'` back into this one.
+ */
+
+import { execFile } from "node:child_process";
+import type { Analyze } from "../permission-gate/index.ts";
+import type { ArgvPipeline } from "../permission-gate/types.ts";
+import { collectPipelines, deferredScripts, nestedScripts, unwrap } from "../permission-gate/shell.ts";
+import { type FlatToken, hasOpaqueCommand, nuPipelines, OPAQUE_HEAD } from "./ast.ts";
+
+const MAX_DEPTH = 4;
+
+// `ast --flatten` tokenizes even input nu would refuse to run, so the parse
+// error is asked for separately. -n keeps user config out of the parser.
+const TOKENIZE =
+	"let s = $in; { error: (ast $s | get error | to nuon), tokens: (ast --flatten $s | select content shape span) } | to json -r";
+
+/** nu's tokens for `script`. Rejects when nu is missing, hangs or reports a parse error. */
+export function tokenize(script: string, nu = "nu"): Promise<FlatToken[]> {
+	return new Promise((resolve, reject) => {
+		const child = execFile(nu, ["-n", "--stdin", "-c", TOKENIZE], { timeout: 5_000, maxBuffer: 16 << 20 }, (err, stdout) => {
+			if (err) return reject(err);
+			try {
+				const { error, tokens } = JSON.parse(stdout) as { error: string; tokens: FlatToken[] };
+				if (error === '"None"') resolve(tokens);
+				else reject(new Error(error.replace(/\s+/g, " ")));
+			} catch (e) {
+				reject(e);
+			}
+		});
+		child.stdin?.end(script);
+	});
+}
+
+/** X in `nu -c X`, `-c=X`, `--commands X`, `--commands=X`. */
+function nuInlineScript(argv: string[]): string | undefined {
+	for (let i = 1; i < argv.length; i++) {
+		if (argv[i] === "-c" || argv[i] === "--commands") return argv[i + 1];
+		const joined = /^(?:-c|--commands)=(["'`]?)([\s\S]*)\1$/.exec(argv[i]);
+		if (joined) return joined[2];
+	}
+	return undefined;
+}
+
+async function collect(script: string, nu: string, depth: number): Promise<ArgvPipeline[]> {
+	if (depth > MAX_DEPTH) return [[[OPAQUE_HEAD]]];
+	const own = nuPipelines(script, await tokenize(script, nu));
+	const forwarded: ArgvPipeline[] = [];
+	for (const argv of own.flat()) {
+		const cmd = unwrap(argv);
+		const isNu = cmd[0].split("/").pop() === "nu";
+		const nuScript = isNu ? nuInlineScript(cmd) : undefined;
+		if (nuScript !== undefined) {
+			forwarded.push(...(await collect(nuScript, nu, depth + 1)));
+		} else {
+			for (const sh of [...nestedScripts(cmd), ...deferredScripts(cmd)]) forwarded.push(...collectPipelines(sh));
+		}
+	}
+	return [...own, ...forwarded];
+}
+
+export const analyzeNu = (nu: string): Analyze => async (command) => {
+	try {
+		const pipelines = await collect(command, nu, 0);
+		return { pipelines, unverified: hasOpaqueCommand(pipelines) ? "command name built at runtime" : undefined };
+	} catch (err) {
+		return { pipelines: [], unverified: `nu parse failed: ${(err as Error).message}` };
+	}
+};

--- a/nushell/index.ts
+++ b/nushell/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Replaces the `bash` tool's interpreter with Nushell and gates it with
+ * permission-gate's rules, parsed by nu itself (gate.ts). Supersedes the
+ * permission-gate extension (same /gate command, config and rules); load
+ * one or the other. Without `nu` in PATH it degrades to plain
+ * permission-gate over the built-in bash tool.
+ *
+ * `$XDG_CONFIG_HOME/nushell/pi.nu` is sourced before every script if it exists.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { createBashTool } from "@mariozechner/pi-coding-agent";
+import permissionGate, { createGate } from "../permission-gate/index.ts";
+import { analyzeNu } from "./gate.ts";
+
+export default function (pi: ExtensionAPI) {
+	let nu: string;
+	try {
+		nu = execFileSync("which", ["nu"], { encoding: "utf8" }).trim();
+	} catch {
+		return permissionGate(pi);
+	}
+	createGate(pi, analyzeNu(nu));
+
+	// There is no tty: nu would draw box tables clipped to 80 columns with
+	// "..." cells. Light borders, no index column and a wide render keep
+	// output complete and cheap in tokens. pi.nu may override.
+	const prefix = [
+		'$env.config.table.mode = "light"',
+		'$env.config.table.index_mode = "never"',
+		"$env.config.footer_mode = \"never\"",
+		"$env.config.hooks.display_output = { table --expand --width 200 }",
+	];
+	const rc = join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "nushell", "pi.nu");
+	if (existsSync(rc)) prefix.push(`source ${JSON.stringify(rc)}`);
+	const bash = createBashTool(process.cwd(), { shellPath: nu, commandPrefix: prefix.join("; ") });
+	pi.registerTool({
+		...bash,
+		label: "nushell",
+		description:
+			"Execute a Nushell (nu) script in the current working directory — this tool runs nu, NOT bash/POSIX sh. " +
+			"Returns stdout and stderr, truncated to the last 2000 lines or 50KB. Optional timeout in seconds.",
+		promptSnippet: "Run Nushell scripts (nu syntax, not POSIX sh)",
+		promptGuidelines: [
+			"bash tool runs Nushell: no `&&`, `$(...)`, `>`, `export` or heredocs; use `;`, `(...)`, `| save file`, `$env.FOO = bar`. External commands work as usual; prefix with `^` when a nu built-in shadows them (`^ls`, `^rm`).",
+			"bash tool runs Nushell: only the *last* expression's value is shown; use `print` (or `| print`) for intermediate results — `ls; open x.json` shows just the json.",
+			"bash tool runs Nushell: prefer structured pipelines over text munging (`open x.json | get a.b`, `ls | where size > 1mb`, `| to json`), nuon for data files.",
+			"bash tool runs Nushell: when rewriting a file you read from, `collect` first: `open f.nuon | where x > 1 | collect | save -f f.nuon`.",
+		],
+	});
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "direnv",
       "fetch",
       "notify",
-      "permission-gate",
+      "nushell",
       "questionnaire",
       "slow-mode",
       "stash",

--- a/permission-gate/index.ts
+++ b/permission-gate/index.ts
@@ -21,13 +21,13 @@
  */
 
 import type { ExtensionAPI, ExtensionContext, BashToolCallEvent } from "@mariozechner/pi-coding-agent";
-import { EVENTS, type CompiledRule, type GateHelpers, type WarnFn } from "./types.ts";
+import { EVENTS, type ArgvPipeline, type CompiledRule, type GateHelpers, type WarnFn } from "./types.ts";
 import { searchPaths } from "./builtin-rules.ts";
 import { anyCmd, hasFlag } from "./helpers.ts";
-import { deferredScripts, nestedScripts, pipelines, SHELLS, simpleCommands, unwrap, unwrapSteps } from "./shell.ts";
+import { collectPipelines, deferredScripts, nestedScripts, pipelines, SHELLS, simpleCommands, unwrap, unwrapSteps } from "./shell.ts";
 import { matchEvidence, matchRules } from "./match.ts";
 import { compileRules, type ConfigLayers, loadConfig, saveUserJson } from "./config.ts";
-import { showReviewPrompt } from "./ui.ts";
+import { type MatchDetail, showReviewPrompt } from "./ui.ts";
 
 const GATE_SUBCMDS = "list(ls)|off <group>|on <group>|add|remove(rm)|reload";
 const HELPERS: GateHelpers = {
@@ -36,9 +36,24 @@ const HELPERS: GateHelpers = {
 	anyCmd, hasFlag, SHELLS,
 };
 
+/**
+ * How a `bash` tool command is turned into pipelines for the argv rules.
+ * The default is the POSIX parser (shell.ts); the nushell extension plugs
+ * in nu's own parser. `unverified` names a reason the analysis is
+ * incomplete (parse error, runtime-built command name) — that prompts on
+ * its own, since an unparsed script is unverified rather than safe.
+ */
+export type Analyze = (command: string) => Promise<{ pipelines: ArgvPipeline[]; unverified?: string }>;
+
+const analyzeSh: Analyze = async (command) => ({ pipelines: collectPipelines(command) });
+
 // ── extension ────────────────────────────────────────────────────────────
 
 export default function permissionGate(pi: ExtensionAPI) {
+	createGate(pi, analyzeSh);
+}
+
+export function createGate(pi: ExtensionAPI, analyze: Analyze): void {
 	// PI_NO_GATE=1 disables the extension entirely (prompts and block
 	// rules). Exact match on "1": treating any non-empty value as a
 	// disable made PI_NO_GATE=0 turn the gate off — the standard env-var
@@ -82,26 +97,30 @@ export default function permissionGate(pi: ExtensionAPI) {
 		// instead of blocking cleanly, and the handler contract is "never
 		// throw" (loadConfig sanitizes; this is defense in depth).
 		let matched: CompiledRule[];
+		let unverified: string | undefined;
 		try {
-			matched = matchRules(command, rules);
+			const analysis = await analyze(command);
+			unverified = analysis.unverified;
+			matched = matchRules(command, rules, analysis.pipelines);
 		} catch (err) {
 			if (ctx.hasUI) {
 				ctx.ui.notify(`permission-gate: rule evaluation failed: ${(err as Error).message}`, "warning");
 			}
 			return { block: true, reason: "Blocked: permission-gate rule evaluation failed — fix the gate config (see /gate list) and retry" };
 		}
-		if (matched.length === 0) return undefined;
-
 		// Block wins over prompt and ignores the /gate toggle.
 		const block = matched.find((r) => r.action === "block");
 		if (block) {
 			return { block: true, reason: block.reason ?? `Blocked (${block.label})` };
 		}
 
-		const prompts = matched.filter((r) => r.action === "prompt");
-		if (!promptsEnabled || prompts.length === 0) return undefined;
+		const matches: MatchDetail[] = matched
+			.filter((r) => r.action === "prompt")
+			.map((r) => ({ label: r.label, evidence: matchEvidence(command, r) }));
+		if (unverified) matches.push({ label: `unverified (${unverified})` });
+		if (!promptsEnabled || matches.length === 0) return undefined;
 
-		const labels = prompts.map((m) => m.label).join(", ");
+		const labels = matches.map((m) => m.label).join(", ");
 		if (!ctx.hasUI) {
 			return { block: true, reason: `Dangerous command blocked (${labels}) — no UI` };
 		}
@@ -109,7 +128,6 @@ export default function permissionGate(pi: ExtensionAPI) {
 		// showReviewPrompt emits EVENTS.waiting itself, *after* arming its
 		// EVENTS.respond listener — emitting it here lost the answer of any
 		// responder that reacted synchronously.
-		const matches = prompts.map((r) => ({ label: r.label, evidence: matchEvidence(command, r) }));
 		const result = await showReviewPrompt(ctx, command, labels, pi.events, matches);
 		pi.events.emit(EVENTS.resolved);
 

--- a/permission-gate/match.ts
+++ b/permission-gate/match.ts
@@ -27,8 +27,7 @@ const MAX_EVIDENCE_LENGTH = 200;
 
 /** All rules matching `command`. Pipelines and the decoded spelling are
  * computed lazily and at most once per call. */
-export function matchRules(command: string, rules: CompiledRule[]): CompiledRule[] {
-	let argvPipes: ArgvPipeline[] | undefined;
+export function matchRules(command: string, rules: CompiledRule[], argvPipes?: ArgvPipeline[]): CompiledRule[] {
 	let decoded: string | undefined;
 	// Regex rules run against the raw string *and* the tokenizer-decoded
 	// words (quotes stripped, escapes decoded, redirect targets included —


### PR DESCRIPTION
Runs pi's `bash` tool with `nu` as interpreter (still `createBashTool`, so streaming/truncation/timeouts are pi's). Falls back to plain permission-gate if `nu` is missing.

permission-gate gets a `createGate(pi, analyze)` hook; the nushell extension plugs in an analyzer that tokenizes scripts with nu itself (`ast --flatten`) and feeds the existing rules. Same `/gate`, rules and config — load one of the two; `package.json` now defaults to `nushell`.